### PR TITLE
[API-2] Subbluedit posts flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,53 @@ Things you may want to cover:
 * Deployment instructions
 
 * ...
+
+## API Usage Examples
+
+### Authentication
+
+Obtain a JWT token (see `/api/v1/auth/google` for Google OAuth2 flow). Use the token in the `Authorization` header for protected endpoints:
+
+```
+Authorization: Bearer <your-jwt-token>
+```
+
+### Create a Subbluedit
+
+```
+POST /api/v1/subbluedits
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{
+  "subbluedit": {
+    "name": "mycommunity",
+    "description": "A place for my people."
+  }
+}
+```
+
+### Show a Subbluedit
+
+```
+GET /api/v1/subbluedits/:id
+```
+
+### Create a Post in a Subbluedit
+
+```
+POST /api/v1/subbluedits/:subbluedit_id/posts
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{
+  "post": {
+    "title": "Hello World",
+    "body": "This is my first post!"
+  }
+}
+```
+
+### Error Responses
+- 401 Unauthorized: If the `Authorization` header is missing or invalid for protected endpoints.
+- 422 Unprocessable Entity: If required parameters are missing or invalid.

--- a/app/controllers/api/v1/posts_controller.rb
+++ b/app/controllers/api/v1/posts_controller.rb
@@ -1,0 +1,21 @@
+module Api
+  module V1
+    class PostsController < ApplicationController
+      def create
+        subbluedit = Subbluedit.find(params[:subbluedit_id])
+        post = subbluedit.posts.build(post_params.merge(user: current_user))
+        if post.save
+          render json: post, status: :created
+        else
+          render json: { errors: post.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      private
+
+      def post_params
+        params.require(:post).permit(:title, :body)
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/subbluedits_controller.rb
+++ b/app/controllers/api/v1/subbluedits_controller.rb
@@ -1,0 +1,27 @@
+module Api
+  module V1
+    class SubblueditsController < ApplicationController
+      skip_before_action :authenticate_request, only: [ :show ]
+
+      def show
+        subbluedit = Subbluedit.find(params[:id])
+        render json: subbluedit, include: :posts
+      end
+
+      def create
+        subbluedit = current_user.subbluedits.build(subbluedit_params)
+        if subbluedit.save
+          render json: subbluedit, status: :created
+        else
+          render json: { errors: subbluedit.errors.full_messages }, status: :unprocessable_entity
+        end
+      end
+
+      private
+
+      def subbluedit_params
+        params.require(:subbluedit).permit(:name, :description)
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/subbluedits_controller.rb
+++ b/app/controllers/api/v1/subbluedits_controller.rb
@@ -4,8 +4,12 @@ module Api
       skip_before_action :authenticate_request, only: [ :show ]
 
       def show
-        subbluedit = Subbluedit.find(params[:id])
-        render json: subbluedit, include: :posts
+        subbluedit = Subbluedit.find_by(name: params[:id])
+        if subbluedit
+          render json: subbluedit, include: :posts
+        else
+          render json: { error: "Subbluedit not found" }, status: :not_found
+        end
       end
 
       def create

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,0 +1,10 @@
+class Post < ApplicationRecord
+  belongs_to :user
+  belongs_to :subbluedit
+
+  validates :title, presence: true
+  validates :body, presence: true
+
+  # id: uuid
+  self.primary_key = :id
+end

--- a/app/models/subbluedit.rb
+++ b/app/models/subbluedit.rb
@@ -1,0 +1,10 @@
+class Subbluedit < ApplicationRecord
+  belongs_to :user
+  has_many :posts, dependent: :destroy
+
+  # id: uuid
+  self.primary_key = :id
+
+  validates :name, presence: true, uniqueness: true
+  validates :description, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,5 @@
 class User < ApplicationRecord
   has_many :identities, dependent: :destroy
+  has_many :subbluedits, dependent: :destroy
+  has_many :posts, dependent: :destroy
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,9 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       post "auth/google", to: "authentication#google_oauth2"
+      resources :subbluedits, only: [ :show, :create ] do
+        resources :posts, only: [ :create ]
+      end
     end
   end
 end

--- a/db/migrate/20250728163843_create_subbluedits.rb
+++ b/db/migrate/20250728163843_create_subbluedits.rb
@@ -1,0 +1,13 @@
+class CreateSubbluedits < ActiveRecord::Migration[8.0]
+  def change
+    enable_extension 'pgcrypto' unless extension_enabled?('pgcrypto')
+    create_table :subbluedits, id: :uuid do |t|
+      t.string :name, null: false
+      t.text :description, null: false
+      t.references :user, null: false, foreign_key: true, type: :bigint
+
+      t.timestamps
+    end
+    add_index :subbluedits, :name, unique: true
+  end
+end

--- a/db/migrate/20250728163943_create_posts.rb
+++ b/db/migrate/20250728163943_create_posts.rb
@@ -1,0 +1,12 @@
+class CreatePosts < ActiveRecord::Migration[8.0]
+  def change
+    create_table :posts, id: :uuid do |t|
+      t.string :title, null: false
+      t.text :body, null: false
+      t.references :user, null: false, foreign_key: true, type: :bigint
+      t.references :subbluedit, null: false, foreign_key: true, type: :uuid
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_07_27_194657) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_28_163943) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+  enable_extension "pgcrypto"
 
   create_table "identities", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -22,6 +23,27 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_27_194657) do
     t.datetime "updated_at", null: false
     t.index ["user_id", "provider"], name: "index_identities_on_user_id_and_provider", unique: true
     t.index ["user_id"], name: "index_identities_on_user_id"
+  end
+
+  create_table "posts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "title", null: false
+    t.text "body", null: false
+    t.bigint "user_id", null: false
+    t.uuid "subbluedit_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["subbluedit_id"], name: "index_posts_on_subbluedit_id"
+    t.index ["user_id"], name: "index_posts_on_user_id"
+  end
+
+  create_table "subbluedits", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "name", null: false
+    t.text "description", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_subbluedits_on_name", unique: true
+    t.index ["user_id"], name: "index_subbluedits_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -34,4 +56,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_27_194657) do
   end
 
   add_foreign_key "identities", "users"
+  add_foreign_key "posts", "subbluedits"
+  add_foreign_key "posts", "users"
+  add_foreign_key "subbluedits", "users"
 end

--- a/test/controllers/api_v1_posts_controller_test.rb
+++ b/test/controllers/api_v1_posts_controller_test.rb
@@ -1,0 +1,31 @@
+require "test_helper"
+
+class ApiV1PostsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:one)
+    @token = JWT.encode({ user_id: @user.id }, Rails.application.secret_key_base)
+    @subbluedit = subbluedits(:one)
+  end
+
+  test "should not create post without auth" do
+    post api_v1_subbluedit_posts_url(@subbluedit), params: { post: { title: "T", body: "B" } }
+    assert_response :unauthorized
+  end
+
+  test "should create post with auth" do
+    assert_difference("Post.count") do
+      post api_v1_subbluedit_posts_url(@subbluedit),
+        params: { post: { title: "New Post", body: "Body text" } },
+        headers: { "Authorization" => "Bearer #{@token}" }
+    end
+    assert_response :created
+    assert_match "New Post", @response.body
+  end
+
+  test "should not create post with invalid params" do
+    post api_v1_subbluedit_posts_url(@subbluedit),
+      params: { post: { title: "", body: "" } },
+      headers: { "Authorization" => "Bearer #{@token}" }
+    assert_response :unprocessable_entity
+  end
+end

--- a/test/controllers/api_v1_subbluedits_controller_test.rb
+++ b/test/controllers/api_v1_subbluedits_controller_test.rb
@@ -8,7 +8,7 @@ class ApiV1SubblueditsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should show subbluedit" do
-    get api_v1_subbluedit_url(@subbluedit)
+    get api_v1_subbluedit_url(@subbluedit.name)
     assert_response :success
     assert_match @subbluedit.name, @response.body
   end

--- a/test/controllers/api_v1_subbluedits_controller_test.rb
+++ b/test/controllers/api_v1_subbluedits_controller_test.rb
@@ -1,0 +1,37 @@
+require "test_helper"
+
+class ApiV1SubblueditsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:one)
+    @token = JWT.encode({ user_id: @user.id }, Rails.application.secret_key_base)
+    @subbluedit = subbluedits(:one)
+  end
+
+  test "should show subbluedit" do
+    get api_v1_subbluedit_url(@subbluedit)
+    assert_response :success
+    assert_match @subbluedit.name, @response.body
+  end
+
+  test "should not create subbluedit without auth" do
+    post api_v1_subbluedits_url, params: { subbluedit: { name: "Test", description: "Desc" } }
+    assert_response :unauthorized
+  end
+
+  test "should create subbluedit with auth" do
+    assert_difference("Subbluedit.count") do
+      post api_v1_subbluedits_url,
+        params: { subbluedit: { name: "TestSub", description: "A desc" } },
+        headers: { "Authorization" => "Bearer #{@token}" }
+    end
+    assert_response :created
+    assert_match "TestSub", @response.body
+  end
+
+  test "should not create subbluedit with invalid params" do
+    post api_v1_subbluedits_url,
+      params: { subbluedit: { name: "", description: "" } },
+      headers: { "Authorization" => "Bearer #{@token}" }
+    assert_response :unprocessable_entity
+  end
+end

--- a/test/fixtures/identities.yml
+++ b/test/fixtures/identities.yml
@@ -2,10 +2,10 @@
 
 one:
   user: one
-  provider: MyString
-  provider_id: MyString
+  provider: google
+  provider_id: google_user_1
 
 two:
   user: two
-  provider: MyString
-  provider_id: MyString
+  provider: google
+  provider_id: google_user_2

--- a/test/fixtures/posts.yml
+++ b/test/fixtures/posts.yml
@@ -1,0 +1,15 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+  title: Test Post
+  body: This is a test post.
+  user: one
+  subbluedit: one
+
+two:
+  id: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+  title: Another Post
+  body: This is another test post.
+  user: two
+  subbluedit: two

--- a/test/fixtures/posts.yml
+++ b/test/fixtures/posts.yml
@@ -1,14 +1,12 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
   title: Test Post
   body: This is a test post.
   user: one
   subbluedit: one
 
 two:
-  id: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
   title: Another Post
   body: This is another test post.
   user: two

--- a/test/fixtures/subbluedits.yml
+++ b/test/fixtures/subbluedits.yml
@@ -1,13 +1,11 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  id: "11111111-1111-1111-1111-111111111111"
   name: MySubbluedit
   description: A test subbluedit
   user: one
 
 two:
-  id: "22222222-2222-2222-2222-222222222222"
   name: AnotherSubbluedit
   description: Another test subbluedit
   user: two

--- a/test/fixtures/subbluedits.yml
+++ b/test/fixtures/subbluedits.yml
@@ -1,0 +1,13 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  id: "11111111-1111-1111-1111-111111111111"
+  name: MySubbluedit
+  description: A test subbluedit
+  user: one
+
+two:
+  id: "22222222-2222-2222-2222-222222222222"
+  name: AnotherSubbluedit
+  description: Another test subbluedit
+  user: two

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,11 +1,11 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  name: MyString
-  email: MyString
-  avatar_url: MyString
+  name: Test User One
+  email: user1@example.com
+  avatar_url: https://example.com/avatar1.jpg
 
 two:
-  name: MyString
-  email: MyString
-  avatar_url: MyString
+  name: Test User Two
+  email: user2@example.com
+  avatar_url: https://example.com/avatar2.jpg

--- a/test/integration/api_v1_posts_flow_test.rb
+++ b/test/integration/api_v1_posts_flow_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+
+class ApiV1PostsFlowTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:one)
+    @token = JWT.encode({ user_id: @user.id }, Rails.application.secret_key_base)
+    @subbluedit = subbluedits(:one)
+  end
+
+  test "can create post with auth" do
+    post api_v1_subbluedit_posts_url(@subbluedit),
+      params: { post: { title: "Flow Post", body: "Body text" } },
+      headers: { "Authorization" => "Bearer #{@token}" }
+    assert_response :created
+    assert_match "Flow Post", @response.body
+  end
+
+  test "cannot create post without auth" do
+    post api_v1_subbluedit_posts_url(@subbluedit), params: { post: { title: "NoAuth", body: "desc" } }
+    assert_response :unauthorized
+  end
+end

--- a/test/integration/api_v1_subbluedits_flow_test.rb
+++ b/test/integration/api_v1_subbluedits_flow_test.rb
@@ -11,9 +11,9 @@ class ApiV1SubblueditsFlowTest < ActionDispatch::IntegrationTest
       params: { subbluedit: { name: "FlowSub", description: "Flow desc" } },
       headers: { "Authorization" => "Bearer #{@token}" }
     assert_response :created
-    sub_id = JSON.parse(@response.body)["id"]
+    sub_name = JSON.parse(@response.body)["name"]
 
-    get api_v1_subbluedit_url(sub_id)
+    get api_v1_subbluedit_url(sub_name)
     assert_response :success
     assert_match "FlowSub", @response.body
   end

--- a/test/integration/api_v1_subbluedits_flow_test.rb
+++ b/test/integration/api_v1_subbluedits_flow_test.rb
@@ -1,0 +1,25 @@
+require "test_helper"
+
+class ApiV1SubblueditsFlowTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:one)
+    @token = JWT.encode({ user_id: @user.id }, Rails.application.secret_key_base)
+  end
+
+  test "can create and fetch subbluedit with auth" do
+    post api_v1_subbluedits_url,
+      params: { subbluedit: { name: "FlowSub", description: "Flow desc" } },
+      headers: { "Authorization" => "Bearer #{@token}" }
+    assert_response :created
+    sub_id = JSON.parse(@response.body)["id"]
+
+    get api_v1_subbluedit_url(sub_id)
+    assert_response :success
+    assert_match "FlowSub", @response.body
+  end
+
+  test "cannot create subbluedit without auth" do
+    post api_v1_subbluedits_url, params: { subbluedit: { name: "NoAuth", description: "desc" } }
+    assert_response :unauthorized
+  end
+end

--- a/test/models/post_test.rb
+++ b/test/models/post_test.rb
@@ -1,0 +1,4 @@
+require "test_helper"
+
+class PostTest < ActiveSupport::TestCase
+end

--- a/test/models/subbluedit_test.rb
+++ b/test/models/subbluedit_test.rb
@@ -1,0 +1,4 @@
+require "test_helper"
+
+class SubblueditTest < ActiveSupport::TestCase
+end


### PR DESCRIPTION
This PR implements the core data models and RESTful API endpoints for Subbluedits and Posts, completing the backend foundation for the Reddit-like application.

Changes:
- Added Subbluedit and Post models with UUID primary keys
- Established proper relationships between User, Subbluedit, and Post models
- Protected creation endpoints with JWT authentication
- Added nested RESTful routes under /api/v1
- Comprehensive test coverage with controller and integration tests
- Updated README with API usage examples